### PR TITLE
Actually substitute the sender address in the message/call data

### DIFF
--- a/src/helpers/formatTxMessageResponse.ts
+++ b/src/helpers/formatTxMessageResponse.ts
@@ -9,11 +9,14 @@ export function formatTxMessageResponse({ txMessage, senderAddress }: Props) {
 
   const updatedTxMessage = {
     ...txMessage,
-    message: {
-      ...txMessage.message,
+    rpcProxySubmissionParams: {
+      ...txMessage.rpcProxySubmissionParams,
       message: {
-        ...txMessage.message.message,
-        from: senderAddress,
+        ...txMessage.rpcProxySubmissionParams.message,
+        message: {
+          ...txMessage.rpcProxySubmissionParams.message.message,
+          from: senderAddress,
+        }
       },
     }
   }

--- a/src/pages/api/paymentTxParams/[uuid].ts
+++ b/src/pages/api/paymentTxParams/[uuid].ts
@@ -21,7 +21,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(400).json({ message: 'Invalid sender address' });
       }
 
-      const paymentTxOrMsg = await getPaymentTxOrMsg(uuid as string);
+      const paymentTxOrMsg = await getPaymentTxOrMsg(uuid as string, senderAddress as string);
       res.status(200).json(paymentTxOrMsg);
     } catch (error) {
       console.error('Error retrieving payment transaction:', error);


### PR DESCRIPTION
Currently the sender address isn't getting substituted into the message and the contract call data for signing and submitting