### PR TITLE
[TRIVIAL] Append the tx hash to the uuid

### DIFF
--- a/src/pages/api/submitPaymentTx/index.ts
+++ b/src/pages/api/submitPaymentTx/index.ts
@@ -50,15 +50,11 @@ export default async function handler(
   );
   const txParams = [from, to, value, validAfter, validBefore, nonce, v, r, s];
 
-  console.log(txParams);
-
   // estimate gas
   const estimatedGasLimit =
     await contract.estimateGas.transferWithAuthorization.apply(null, txParams);
 
   // generate unsigned tx
-
-
   const tx = await contract.populateTransaction.transferWithAuthorization.apply(
     null,
     txParams
@@ -76,6 +72,9 @@ export default async function handler(
 
   try {
     const txSubmission = await provider.sendTransaction(signedTx);
+    const txHash = txSubmission.hash;
+    await appendTxHashToPayment(uuid, txHash);
+
     res.status(200).json({ data: txSubmission });
   } catch (err: any) {
     // TODO: Report error somehwere


### PR DESCRIPTION
Upon receiving the EIP-712 signature in the submitPaymentTx endpoint, we submit the transaction onchain on the user's behalf. This PR takes the tx hash that we get from submitting the tx and updates the entry in the NFC relayer database with the tx hash. This will notify the merchant dapp that the customer has submitted a transaction.