### PR TITLE
[TRIVIAL] Rename message field to typedData

### DIFF
--- a/src/helpers/formatTxMessageResponse.ts
+++ b/src/helpers/formatTxMessageResponse.ts
@@ -11,10 +11,10 @@ export function formatTxMessageResponse({ txMessage, senderAddress }: Props) {
     ...txMessage,
     rpcProxySubmissionParams: {
       ...txMessage.rpcProxySubmissionParams,
-      message: {
-        ...txMessage.rpcProxySubmissionParams.message,
+      typedData: {
+        ...txMessage.rpcProxySubmissionParams.typedData,
         message: {
-          ...txMessage.rpcProxySubmissionParams.message.message,
+          ...txMessage.rpcProxySubmissionParams.typedData.message,
           from: senderAddress,
         }
       },

--- a/src/pages/api/submitPaymentTx/index.ts
+++ b/src/pages/api/submitPaymentTx/index.ts
@@ -25,9 +25,9 @@ export default async function handler(
     return res.status(500);
   }
 
-  const { message, signature, uuid, txHash } = req.body;
-  const { from, to, value, nonce, validAfter, validBefore } = message.message;
-  const { chainId } = message.domain;
+  const { typedData, signature, uuid, txHash } = req.body;
+  const { from, to, value, nonce, validAfter, validBefore } = typedData.message;
+  const { chainId } = typedData.domain;
 
   const sponsoredInfo = sponsoredUsdcMapping.find((s) => s.chainId === Number(chainId));
   if (!sponsoredInfo) {

--- a/src/types/paymentTx.ts
+++ b/src/types/paymentTx.ts
@@ -49,5 +49,5 @@ export function isContractCallPayload(payload: Payload): payload is ContractCall
 }
 
 export function isEip712Payload(payload: Payload): payload is Eip712Payload {
-  return payload.payloadType === 'eip712' && 'rpcProxySubmissionParams' in payload && 'message' in payload.rpcProxySubmissionParams;
+  return payload.payloadType === 'eip712' && 'rpcProxySubmissionParams' in payload && 'typedData' in payload.rpcProxySubmissionParams;
 }


### PR DESCRIPTION
Renames the `message` field at the top level to `typedData` so that it's clear that the customer needs to sign a typed data, not just a regular message.